### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/marcosleal0773/c3d7d8e4-8a28-4885-a45b-1aa165133225/4168552b-c17d-4502-8782-8e7c1ea2cfa4/_apis/work/boardbadge/c7db3c0c-4e7d-4624-a133-d175cf1a9bb0)](https://dev.azure.com/marcosleal0773/c3d7d8e4-8a28-4885-a45b-1aa165133225/_boards/board/t/4168552b-c17d-4502-8782-8e7c1ea2cfa4/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/marcosleal0773/c3d7d8e4-8a28-4885-a45b-1aa165133225/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.